### PR TITLE
Fix non-static access to the static property

### DIFF
--- a/lib/actions/shopOnestepPluginFrontendOnestep.action.php
+++ b/lib/actions/shopOnestepPluginFrontendOnestep.action.php
@@ -654,11 +654,11 @@ class shopOnestepPluginFrontendOnestepAction extends shopFrontendAction {
     }
 
     protected function getStep($step_id) {
-        if (!isset($this->steps[$step_id])) {
+        if (!isset(self::$steps[$step_id])) {
             $class_name = 'shopOnestepCheckout' . ucfirst($step_id);
-            $this->steps[$step_id] = new $class_name();
+            self::$steps[$step_id] = new $class_name();
         }
-        return $this->steps[$step_id];
+        return self::$steps[$step_id];
     }
 
 }


### PR DESCRIPTION
Доступ к статическим свойствам класса не должен получаться через оператор `->` [документация](http://php.net/manual/ru/language.oop5.static.php)
