### PR TITLE
У плагина оплаты может вовсе не быть свойства 'icon'

### DIFF
--- a/lib/classes/checkout/shopOnestepCheckoutPayment.class.php
+++ b/lib/classes/checkout/shopOnestepCheckoutPayment.class.php
@@ -28,7 +28,7 @@ class shopOnestepCheckoutPayment extends shopCheckoutPayment {
             }
             $plugin = shopPayment::getPlugin($m['plugin'], $m['id']);
             $plugin_info = $plugin->info($m['plugin']);
-            $methods[$key]['icon'] = $plugin_info['icon'];
+            $methods[$key]['icon'] = ifset($plugin_info['icon'], '');
             $custom_fields = $this->getCustomFields($method_id, $plugin);
             $custom_html = '';
             foreach ($custom_fields as $c) {


### PR DESCRIPTION
Например если создать способ оплаты "Оплата в ручном режиме" в shop-script 8, то будет использоваться "виртуальный" плагин dummy, у которого совсем нет поля 'icon'. Из-за этого на экран (или php-error.log) валятся notices типа ` Trying to access array offset on value of type null in /wa-apps/shop/plugins/onestep/lib/classes/checkout/shopOnestepCheckoutPayment.class.php on line 31`