### PR TITLE
Заменять роутинг только при запросах из общедоступной части сайта

### DIFF
--- a/lib/shopOnestep.plugin.php
+++ b/lib/shopOnestep.plugin.php
@@ -133,6 +133,10 @@ class shopOnestepPlugin extends shopPlugin {
             return;
         }
 
+        if(wa()->getEnv() !== 'frontend') {
+            return [];
+        }
+        
         if (shopOnestepHelper::getRouteSettings(null, 'status')) {
             $route_settings = shopOnestepHelper::getRouteSettings();
         } elseif (shopOnestepHelper::getRouteSettings(0, 'status')) {


### PR DESCRIPTION
В современных версиях Shop-Script хук `routig` вызывается в том числе и из бэкенда (административной части). При этом (при вы зове из бэкенда) хелпер плагина не получает таблицу роутинга и опять же сыпет notices `Trying to access array offset on value of type null in /wa-apps/shop/plugins/onestep/lib/classes/shopOnestepHelper.class.php on line 101`.  Предлагаемое изменение позволяет перезаписывать роутинг только для фронтенда